### PR TITLE
Fix Use of uninitialized value $value in lc

### DIFF
--- a/lib/Wiki/Toolkit/Store/Database.pm
+++ b/lib/Wiki/Toolkit/Store/Database.pm
@@ -1739,7 +1739,7 @@ sub list_nodes_by_missing_metadata {
     my $dbh = $self->dbh;
     if ( $args{ignore_case} ) {
         $type  = lc( $type  );
-        $value = lc( $value );
+        $value = lc( $value || "");
     }
 
     my @nodes;


### PR DESCRIPTION
[from http://www.wiki-toolkit.org/ticket/51]

Seen in openguides test output with perl 5.12.3:

    t/71_missing_metadata.t .................. 1/26 Use of uninitialized value $value in lc at /usr/share/perl/Wiki/Toolkit/Store/Database.pm line 1741.
    Use of uninitialized value $value in lc at /usr/share/perl5/Wiki/Toolkit/Store/Database.pm line 1741.

This is also ​http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=627130

Changed 5 years ago by bob

I think this is a valid warning from Wiki::Toolkit given what t/71_missing_metadata.t does. It creates a node with some metadata which has no value which in the normal scheme things shouldn't happen.

Changed 5 years ago by bob

this patch probably needs thinking about.
