### PR TITLE
Avoid double encoding with DBD::Pg and pg_enable_utf8=0

### DIFF
--- a/lib/Wiki/Toolkit/Store/Database.pm
+++ b/lib/Wiki/Toolkit/Store/Database.pm
@@ -587,11 +587,14 @@ sub write_node_post_locking {
 
         # Update the node only if node doesn't require moderation
         if(!$node_requires_moderation) {
-            $sql = "UPDATE node SET version=" . $dbh->quote($version)
-             . ", text=" . $dbh->quote($self->charset_encode($content))
-             . ", modified=" . $dbh->quote($timestamp)
-             . " WHERE name=" . $dbh->quote($self->charset_encode($node));
-            $dbh->do($sql) or croak "Error updating database: " . DBI->errstr;
+            $sql = "UPDATE node SET version=?"
+                . ", text=?"
+                . ",modified=?"
+                . " WHERE NAME=?";
+            my $sth = $dbh->prepare($sql);
+            $sth->execute(map { $self->charset_encode($_) }
+                              ($version,$content,$timestamp,$node)
+                      )  or croak "Error updating database: " . DBI->errstr;
         }
 
         # You can't use this to enable moderation on an existing node

--- a/t/028_crud_utf8.t
+++ b/t/028_crud_utf8.t
@@ -1,0 +1,61 @@
+# Purpose: create, read, update, and delete a node with charset => UTF-8
+
+use strict;
+use Wiki::Toolkit::TestLib;
+use Test::More;
+
+if ( scalar @Wiki::Toolkit::TestLib::wiki_info == 0 ) {
+    plan skip_all => "no backends configured";
+} else {
+    plan tests => 7 * scalar @Wiki::Toolkit::TestLib::wiki_info;
+}
+
+my $node_name = 'Whatever';
+my $content   = 'ö';
+
+my $iterator = Wiki::Toolkit::TestLib->new_wiki_maker;
+
+while ( my $wiki = $iterator->new_wiki ) {
+    my $store = $wiki->store;
+    my ($db_engine) = ref($store) =~/([^:]+$)/;
+    $store->{_charset} = 'UTF-8';
+
+    # Test a simple write and retrieve.
+    ok (eval { $wiki->write_node($node_name, $content) },
+        "$db_engine: write_node with non-ASCII content" );
+  SKIP: {
+        if ($@) {
+            diag substr($@,0,70) . " ...";
+            skip "$db_engine: Node could not be written, skip retrieve and update tests", 6;
+        }
+
+        my $char_length = $store->dbh->selectrow_array(
+            "SELECT LENGTH(text) FROM node WHERE name = '$node_name'" );
+        is( $char_length, length($content),
+            "$db_engine: Content has expected length" );
+
+        my %node = $wiki->retrieve_node( $node_name );
+        is( $node{content}, $content,
+            "$db_engine: retrieve_node can retrieve it" );
+
+        # Test ->node_exists.
+        ok( $wiki->node_exists($node_name),
+            "$db_engine: node_exists returns true for an existing node" );
+
+        my $version  = $node{version} + 1;
+        my $content  = "Version $version: $node{content}";
+        my $checksum = $node{checksum};
+
+        ok( $wiki->write_node($node_name, $content, $checksum),
+            "$db_engine: Update successful");
+        %node = $wiki->retrieve_node($node_name);
+
+        is( $node{content}, $content,
+            "$db_engine: Read after update provides correct content" );
+
+        # Cleanup
+        $wiki->delete_node(name => $node_name);
+        ok( ! $wiki->node_exists($node_name),
+            "$db_engine: node_exists returns false after deleting the node" );
+    }
+}

--- a/t/029_crud_utf8_workaround.t
+++ b/t/029_crud_utf8_workaround.t
@@ -1,0 +1,80 @@
+# Purpose: create, read, update, and delete a node with charset => UTF-8
+# with the workaround to disable PostgreSQL encoding (pg_utf8_enable = 0)
+# For SQLite, the UTF-8 flag is not enabled per default.
+
+use strict;
+use Wiki::Toolkit::TestLib;
+use Test::More;
+
+my @nodes = (
+    [ 'ascii node name'      => 'a' ],
+    [ 'non-ascii node name'  => 'ö' ],
+);
+
+if ( scalar @Wiki::Toolkit::TestLib::wiki_info == 0 ) {
+    plan skip_all => "no backends configured";
+} else {
+    plan tests => 7 * scalar @Wiki::Toolkit::TestLib::wiki_info;
+}
+
+my $node_name = 'Whatever';
+my $content   = 'ö';
+
+my $iterator = Wiki::Toolkit::TestLib->new_wiki_maker;
+
+while ( my $wiki = $iterator->new_wiki ) {
+    my $store = $wiki->store;
+    my ($db_engine) = ref($store) =~/([^:]+$)/;
+    $store->{_charset} = 'UTF-8';
+
+    # discard store's dbh and set up a new one, pg_enable_utf8 disabled
+    my $old_dbh = $store->dbh;
+    my $dsn = $store->_dsn($store->dbname,$store->dbhost,$store->{_dbport});
+    my $new_dbh = DBI->connect( $dsn,
+                                $store->dbuser,$store->dbpass,
+                                { %{$store->_get_dbh_connect_attr},
+                                  pg_enable_utf8 => 0,
+                                },
+                              )
+        or die "Can't connect to database $store->dbname: " . DBI->errstr;
+    $store->{_dbh} = $new_dbh;
+
+    # Test a simple write and retrieve.
+    ok (eval { $wiki->write_node($node_name, $content) },
+        "$db_engine: write_node with non-ASCII content" );
+  SKIP: {
+        if ($@) {
+            diag substr($@,0,70) . " ...";
+            skip "$db_engine: Node could not be written, skip retrieve and update tests", 6;
+        }
+
+        my $char_length = $store->dbh->selectrow_array(
+            "SELECT LENGTH(text) FROM node WHERE name = '$node_name'" );
+        is( $char_length, length($content),
+            "$db_engine: Content has expected length" );
+
+        my %node = $wiki->retrieve_node( $node_name );
+        is( $node{content}, $content,
+            "$db_engine: retrieve_node can retrieve it" );
+
+        # Test ->node_exists.
+        ok( $wiki->node_exists($node_name),
+            "$db_engine: node_exists returns true for an existing node" );
+
+        my $version  = $node{version} + 1;
+        my $content  = "Version $version: $node{content}";
+        my $checksum = $node{checksum};
+
+        ok( $wiki->write_node($node_name, $content, $checksum),
+            "$db_engine: Update successful");
+        %node = $wiki->retrieve_node($node_name);
+
+        is( $node{content}, $content,
+            "$db_engine: Read after update provides correct content" );
+
+        # Cleanup
+        $wiki->delete_node(name => $node_name);
+        ok( ! $wiki->node_exists($node_name),
+            "$db_engine: node_exists returns false after deleting the node" );
+    }
+}


### PR DESCRIPTION
Act (A Conference Toolkit) http://act.mongueurs.net/ is an application based on Wiki::Toolkit and used for Perl conferences in Europe.  Since an upgrade of DBD::Pg we experience encoding issues with non-ASCII characters, which are encoded twice: The current version of DBD::Pg does encoding on its own, and Wiki::Toolkit does it as well.  Act suppresses UTF-8-handling by the database driver by setting the attribute pg_enable_utf8 to 0 - but this isn't entirely complete. 

What we see is that when a new node is stored for the first time, it works just fine.  But then, every edit/save cycle adds another level of over-encoding.  This only affects the current version: All versions of the node in the history are just fine.

I've tracked the difference down to a different handling when storing the texts: The initial version, and all entries in the history table, are done with INSERT using placeholders, while edit/save cycles use a concatenated UPDATE statement.  So, what happens during the concatenation is this:

1. The toolkit encodes all values according to the configured encoding (UTF-8 in our case).  This clears the UTF-8 flag.
2. Then it calls $dbh->quote to quote the encoded parameters. Unfortunately, this re-instates the UTF-8 flag!
3. Finally, the concatenated statement, which inherits the UTF-8-Flag from the values, is passed to DBD::Pg...
4. ...which now feels that it needs to encode the statement _again._

There are two ways to avoid this:

- Use placeholders, like the INSERT statement for new nodes and the history table do.  This way, the encoded parameters keep their UTF-8-flag cleared and DBD::Pg accepts them as they are.
 - First concatenate the SQL statement _without_ encoding the values, and then encode the whole statement in one go. This is another way to keep the UTF-8-flag cleared.

Both alternatives work in my local installation of the Act software.

From the commit message, which implements the first solution:
Change the UPDATE SQL statement which writes the current node text
from a concatenated statement containing encoded values to one using
placeholders: This suppresses unwanted double encoding by DBD::Pg