### PR TITLE
Allow the plugin tests to run with SII search and several DB backends

### DIFF
--- a/t/151_plugin_methods.t
+++ b/t/151_plugin_methods.t
@@ -30,4 +30,6 @@ while ( my $wiki = $iterator->new_wiki ) {
     my $plugin_2 = Wiki::Toolkit::Plugin::Bar->new;
     eval { $wiki->register_plugin( plugin => $plugin_2 ); };
     is( $@, "", "->on_register can access datastore" );
+
+    delete $wiki->{_registered_plugins}; # break cyclic references
 }


### PR DESCRIPTION
In the plugin tests, the Wiki::Toolkit object isn't destroyed when it goes
out of scope because it contains a circular reference with its registered
plugins.   This makes the second test fail with the message
   Attempted to open -map_name 't/sii-db-file-test.db' multiple time

Breaking the circular reference at the end of the test case fixes this.