### PR TITLE
Fix issue with text columns in MySQL strict mode.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,10 @@
         Upgrade database schema to version 11 (text columns no longer have a
           default value, for compatibility with MySQL strict mode).
         Remove code for dealing with upgrades to database schema version 10
-	  (which came in over a decade ago).
+          (which came in over a decade ago).  PLEASE NOTE that if your schema
+          version is older than 10 (see the schema_info table in your database)
+          then you MUST upgrade to version 10 by running wiki-toolkit-setupdb
+          BEFORE you install this version of Wiki::Toolkit.
 
 0.85    16 December 2016
         Make ->rename_node try to ensure a valid new node name (depending on

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.86
+        Upgrade database schema to version 11 (text columns no longer have a
+          default value, for compatibility with MySQL strict mode).
+        Remove code for dealing with upgrades to database schema version 10
+	  (which came in over a decade ago).
+
 0.85    16 December 2016
         Make ->rename_node try to ensure a valid new node name (depending on
           formatter parameters).

--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 0.86
         Upgrade database schema to version 11 (text columns no longer have a
-          default value, for compatibility with MySQL strict mode).
+          default value, for compatibility with MySQL strict mode).  To upgrade
+          your existing databases to the new schema, run wiki-toolkit-setupdb.
+          Use of schema version 10 and upgrades from this to newer versions
+          will continue to be supported for any releases made before
+          31 December 2021.
         Remove code for dealing with upgrades to database schema version 10
           (which came in over a decade ago).  PLEASE NOTE that if your schema
           version is older than 10 (see the schema_info table in your database)

--- a/lib/Wiki/Toolkit/Setup/Database.pm
+++ b/lib/Wiki/Toolkit/Setup/Database.pm
@@ -2,10 +2,12 @@ package Wiki::Toolkit::Setup::Database;
 
 use strict;
 
+use Carp qw( croak );
+
 use vars qw( $VERSION @SUPPORTED_SCHEMAS);
 
-$VERSION = 0.09;
-@SUPPORTED_SCHEMAS = qw(8 9 10);
+$VERSION = 0.11;
+@SUPPORTED_SCHEMAS = qw( 10 11 );
 
 =head1 NAME
 
@@ -14,106 +16,8 @@ classes for Wiki::Toolkit
 
 =cut
 
-sub fetch_upgrade_old_to_8 {
-    # Compatible with old_to_10
-    fetch_upgrade_old_to_10(@_);
-}
-
-sub fetch_upgrade_old_to_9 {
-    # Compatible with old_to_10
-    fetch_upgrade_old_to_10(@_);
-}
-
-# Fetch from the old style database, ready for an upgrade to db version 10
-sub fetch_upgrade_old_to_10 {
-    my $dbh = shift;
-    my %nodes;
-    my %metadatas;
-    my %contents;
-    my @internal_links;
-    my %ids;
-
-    print "Grabbing and upgrading old data... ";
-
-    # Grab all the nodes, and give them an ID
-    my $sth = $dbh->prepare("SELECT name,version,text,modified FROM node");
-    $sth->execute;
-    my $id = 0;
-    while( my($name,$version,$text,$modified) = $sth->fetchrow_array) {
-        my %node;
-        $id++;
-        $node{'name'} = $name;
-        $node{'version'} = $version;
-        $node{'text'} = $text;
-        $node{'modified'} = $modified;
-        $node{'id'} = $id;
-        $node{'moderate'} = 0;
-        $nodes{$name} = \%node;
-        $ids{$name} = $id;
-    }
-    print " read $id nodes...  ";
-
-    # Grab all the content, and upgrade to ID from name
-    $sth = $dbh->prepare("SELECT name,version,text,modified,comment FROM content");
-    $sth->execute;
-    while ( my($name,$version,$text,$modified,$comment) = $sth->fetchrow_array) {
-        my $id = $ids{$name};
-        if($id) {
-            my %content;
-            $content{'node_id'} = $id;
-            $content{'version'} = $version;
-            $content{'text'} = $text;
-            $content{'modified'} = $modified;
-            $content{'comment'} = $comment;
-            $content{'moderated'} = 1;
-            $contents{$id."-".$version} = \%content;
-        } else {
-            warn("There was no node entry for content with name '$name', unable to migrate it!");
-        }
-    }
-    print " read ".(scalar keys %contents)." contents...  ";
-
-    # Grab all the metadata, and upgrade to ID from node
-    $sth = $dbh->prepare("SELECT node,version,metadata_type,metadata_value FROM metadata");
-    $sth->execute;
-    my $i = 0;
-    while( my($node,$version,$metadata_type,$metadata_value) = $sth->fetchrow_array) {
-        my $id = $ids{$node};
-        if($id) {
-            my %metadata;
-            $metadata{'node_id'} = $id;
-            $metadata{'version'} = $version;
-            $metadata{'metadata_type'} = $metadata_type;
-            $metadata{'metadata_value'} = $metadata_value;
-            $metadatas{$id."-".($i++)} = \%metadata;
-        } else {
-            warn("There was no node entry for metadata with name (node) '$node', unable to migrate it!");
-        }
-    }
-
-    # Grab all the internal links
-    $sth = $dbh->prepare("SELECT link_from,link_to FROM internal_links");
-    $sth->execute;
-    while( my($link_from,$link_to) = $sth->fetchrow_array) {
-        my %il;
-        $il{'link_from'} = $link_from;
-        $il{'link_to'} = $link_to;
-        push @internal_links, \%il;
-    }
-
-    print "done\n";
-
-    # Return it all
-    return (\%nodes,\%contents,\%metadatas,\@internal_links,\%ids);
-}
-
-sub fetch_upgrade_8_to_9 {
-    # Compatible with 8_to_10 
-    fetch_upgrade_8_to_10(@_);
-}
-
-# Fetch from schema version 8, and upgrade to version 10
-sub fetch_upgrade_8_to_10 {
+# Fetch from schema version 10, and upgrade to version 11
+sub fetch_upgrade_10_to_11 {
     my $dbh = shift;
     my %nodes;
     my %metadatas;
@@ -123,127 +27,66 @@ sub fetch_upgrade_8_to_10 {
     print "Grabbing and upgrading old data... ";
 
     # Grab all the nodes
-    my $sth = $dbh->prepare("SELECT id,name,version,text,modified FROM node");
+    my $sth = $dbh->prepare( "SELECT id,name,version,text,modified,moderate"
+                             . " FROM node" );
     $sth->execute;
-    while( my($id,$name,$version,$text,$modified) = $sth->fetchrow_array) {
-        my %node;
-        $node{'name'} = $name;
-        $node{'version'} = $version;
-        $node{'text'} = $text;
-        $node{'modified'} = $modified;
-        $node{'id'} = $id;
-        $node{'moderate'} = 0;
-        $nodes{$name} = \%node;
+    while( my( $id, $name, $version, $text, $modified, $moderate) =
+               $sth->fetchrow_array ) {
+        $nodes{$name} = {
+            name => $name,
+            version => $version,
+            text => $text,
+            modified => $modified,
+            id => $id,
+            moderate => $moderate,
+	};
     }
 
     # Grab all the content
-    $sth = $dbh->prepare("SELECT node_id,version,text,modified,comment FROM content");
+    $sth = $dbh->prepare( "SELECT node_id,version,text,modified,comment,"
+                          . "moderated FROM content" );
     $sth->execute;
-    while ( my($node_id,$version,$text,$modified,$comment) = $sth->fetchrow_array) {
-        my %content;
-        $content{'node_id'} = $node_id;
-        $content{'version'} = $version;
-        $content{'text'} = $text;
-        $content{'modified'} = $modified;
-        $content{'comment'} = $comment;
-        $content{'moderated'} = 1;
-        $contents{$node_id."-".$version} = \%content;
+    while ( my( $node_id, $version, $text, $modified, $comment, $moderated) =
+                $sth->fetchrow_array ) {
+        $contents{$node_id."-".$version} = {
+	    node_id => $node_id,
+            version => $version,
+            text => $text,
+            modified => $modified,
+	    comment => $comment,
+            moderated => $moderated,
+	};
     }
 
     # Grab all the metadata
-    $sth = $dbh->prepare("SELECT node_id,version,metadata_type,metadata_value FROM metadata");
+    $sth = $dbh->prepare( "SELECT node_id,version,metadata_type,metadata_value"
+                          . " FROM metadata" );
     $sth->execute;
     my $i = 0;
-    while( my($node_id,$version,$metadata_type,$metadata_value) = $sth->fetchrow_array) {
-        my %metadata;
-        $metadata{'node_id'} = $node_id;
-        $metadata{'version'} = $version;
-        $metadata{'metadata_type'} = $metadata_type;
-        $metadata{'metadata_value'} = $metadata_value;
-        $metadatas{$node_id."-".($i++)} = \%metadata;
+    while( my ( $node_id, $version, $metadata_type, $metadata_value ) =
+           $sth->fetchrow_array) {
+        $metadatas{$node_id."-".($i++)} = {
+	    node_id => $node_id,
+	    version => $version,
+	    metadata_type => $metadata_type,
+	    metadata_value => $metadata_value,
+	};
     }
 
     # Grab all the internal links
-    $sth = $dbh->prepare("SELECT link_from,link_to FROM internal_links");
+    $sth = $dbh->prepare( "SELECT link_from,link_to FROM internal_links" );
     $sth->execute;
-    while( my($link_from,$link_to) = $sth->fetchrow_array) {
-        my %il;
-        $il{'link_from'} = $link_from;
-        $il{'link_to'} = $link_to;
-        push @internal_links, \%il;
+    while( my ( $link_from, $link_to ) = $sth->fetchrow_array ) {
+        push @internal_links, {
+	    link_from => $link_from,
+	    link_to => $link_to,
+	};
     }
 
     print "done\n";
 
     # Return it all
-    return (\%nodes,\%contents,\%metadatas,\@internal_links);
-}
-
-# Fetch from schema version 9, and upgrade to version 10
-sub fetch_upgrade_9_to_10 {
-    my $dbh = shift;
-    my %nodes;
-    my %metadatas;
-    my %contents;
-    my @internal_links;
-
-    print "Grabbing and upgrading old data... ";
-
-    # Grab all the nodes
-    my $sth = $dbh->prepare("SELECT id,name,version,text,modified,moderate FROM node");
-    $sth->execute;
-    while( my($id,$name,$version,$text,$modified,$moderate) = $sth->fetchrow_array) {
-        my %node;
-        $node{'name'} = $name;
-        $node{'version'} = $version;
-        $node{'text'} = $text;
-        $node{'modified'} = $modified;
-        $node{'id'} = $id;
-        $node{'moderate'} = $moderate;
-        $nodes{$name} = \%node;
-    }
-
-    # Grab all the content
-    $sth = $dbh->prepare("SELECT node_id,version,text,modified,comment,moderated FROM content");
-    $sth->execute;
-    while ( my($node_id,$version,$text,$modified,$comment,$moderated) = $sth->fetchrow_array) {
-        my %content;
-        $content{'node_id'} = $node_id;
-        $content{'version'} = $version;
-        $content{'text'} = $text;
-        $content{'modified'} = $modified;
-        $content{'comment'} = $comment;
-        $content{'moderated'} = $moderated;
-        $contents{$node_id."-".$version} = \%content;
-    }
-
-    # Grab all the metadata
-    $sth = $dbh->prepare("SELECT node_id,version,metadata_type,metadata_value FROM metadata");
-    $sth->execute;
-    my $i = 0;
-    while( my($node_id,$version,$metadata_type,$metadata_value) = $sth->fetchrow_array) {
-        my %metadata;
-        $metadata{'node_id'} = $node_id;
-        $metadata{'version'} = $version;
-        $metadata{'metadata_type'} = $metadata_type;
-        $metadata{'metadata_value'} = $metadata_value;
-        $metadatas{$node_id."-".($i++)} = \%metadata;
-    }
-
-    # Grab all the internal links
-    $sth = $dbh->prepare("SELECT link_from,link_to FROM internal_links");
-    $sth->execute;
-    while( my($link_from,$link_to) = $sth->fetchrow_array) {
-        my %il;
-        $il{'link_from'} = $link_from;
-        $il{'link_to'} = $link_to;
-        push @internal_links, \%il;
-    }
-
-    print "done\n";
-
-    # Return it all
-    return (\%nodes,\%contents,\%metadatas,\@internal_links);
+    return ( \%nodes, \%contents, \%metadatas, \@internal_links );
 }
 
 # Get the version of the database schema
@@ -252,14 +95,21 @@ sub get_database_version {
     my $sql = "SELECT version FROM schema_info";
     my $sth;
     eval{ $sth = $dbh->prepare($sql) };
-    if($@) { return "old"; }
+    if($@) { croak_too_old(); }
     eval{ $sth->execute };
-    if($@) { return "old"; }
+    if($@) { croak_too_old(); }
 
     my ($cur_schema) = $sth->fetchrow_array;
-    unless($cur_schema) { return "old"; }
+    if ( !$cur_schema || $cur_schema < $SUPPORTED_SCHEMAS[0] ) {
+        croak_too_old();
+    }
 
     return $cur_schema;
+}
+
+sub croak_too_old {
+    croak "Database schema too old — must be at least version "
+          . $SUPPORTED_SCHEMAS[0];
 }
 
 # Is an upgrade to the database required?
@@ -273,7 +123,7 @@ sub get_database_upgrade_required {
     if($schema_version eq $new_version) {
         # At latest version
         return undef;
-    } elsif ($schema_version eq 'old' or $schema_version < $new_version) {
+    } elsif ( $schema_version < $new_version ) {
         return $schema_version."_to_".$new_version;
     } else {
         die "Aiee! We seem to be trying to downgrade the database schema from $schema_version to $new_version. Aborting.\n";

--- a/lib/Wiki/Toolkit/Setup/SQLite.pm
+++ b/lib/Wiki/Toolkit/Setup/SQLite.pm
@@ -7,7 +7,7 @@ use vars qw( @ISA $VERSION $SCHEMA_VERSION );
 use Wiki::Toolkit::Setup::Database;
 
 @ISA = qw( Wiki::Toolkit::Setup::Database );
-$VERSION = '0.10';
+$VERSION = '0.11';
 
 use DBI;
 use Carp;
@@ -15,100 +15,11 @@ use Carp;
 $SCHEMA_VERSION = $VERSION*100;
 
 my $create_sql = {
-    8 => {
-        schema_info => [ qq|
-CREATE TABLE schema_info (
-  version   integer      NOT NULL default 0
-);
-|, qq|
-INSERT INTO schema_info VALUES (8)
-| ],
-        node => [ qq|
-CREATE TABLE node (
-  id        integer      NOT NULL PRIMARY KEY AUTOINCREMENT,
-  name      varchar(200) NOT NULL DEFAULT '',
-  version   integer      NOT NULL default 0,
-  text      mediumtext   NOT NULL default '',
-  modified  datetime     default NULL
-)
-| ],
-        content => [ qq|
-CREATE TABLE content (
-  node_id   integer      NOT NULL,
-  version   integer      NOT NULL default 0,
-  text      mediumtext   NOT NULL default '',
-  modified  datetime     default NULL,
-  comment   mediumtext   NOT NULL default '',
-  PRIMARY KEY (node_id, version)
-)
-| ],
-        internal_links => [ qq|
-CREATE TABLE internal_links (
-  link_from varchar(200) NOT NULL default '',
-  link_to   varchar(200) NOT NULL default '',
-  PRIMARY KEY (link_from, link_to)
-)
-| ],
-        metadata => [ qq|
-CREATE TABLE metadata (
-  node_id        integer      NOT NULL,
-  version        integer      NOT NULL default 0,
-  metadata_type  varchar(200) NOT NULL DEFAULT '',
-  metadata_value mediumtext   NOT NULL DEFAULT ''
-)
-| ]
-    },
-    9 => {
-        schema_info => [ qq|
-CREATE TABLE schema_info (
-  version   integer      NOT NULL default 0
-);
-|, qq|
-INSERT INTO schema_info VALUES (9)
-| ],
-
-        node => [ qq|
-CREATE TABLE node (
-  id        integer      NOT NULL PRIMARY KEY AUTOINCREMENT,
-  name      varchar(200) NOT NULL DEFAULT '',
-  version   integer      NOT NULL default 0,
-  text      mediumtext   NOT NULL default '',
-  modified  datetime     default NULL,
-  moderate  boolean      NOT NULL default '0'
-)
-| ],
-        content => [ qq|
-CREATE TABLE content (
-  node_id   integer      NOT NULL,
-  version   integer      NOT NULL default 0,
-  text      mediumtext   NOT NULL default '',
-  modified  datetime     default NULL,
-  comment   mediumtext   NOT NULL default '',
-  moderated boolean      NOT NULL default '1',
-  PRIMARY KEY (node_id, version)
-)
-| ],
-        internal_links => [ qq|
-CREATE TABLE internal_links (
-  link_from varchar(200) NOT NULL default '',
-  link_to   varchar(200) NOT NULL default '',
-  PRIMARY KEY (link_from, link_to)
-)
-| ],
-        metadata => [ qq|
-CREATE TABLE metadata (
-  node_id        integer      NOT NULL,
-  version        integer      NOT NULL default 0,
-  metadata_type  varchar(200) NOT NULL DEFAULT '',
-  metadata_value mediumtext   NOT NULL DEFAULT ''
-)
-| ]
-    },
     10 => {
         schema_info => [ qq|
 CREATE TABLE schema_info (
   version   integer      NOT NULL default 0
-); 
+);
 |, qq|
 INSERT INTO schema_info VALUES (10)
 | ],
@@ -121,7 +32,7 @@ CREATE TABLE node (
   text      mediumtext   NOT NULL default '',
   modified  datetime     default NULL,
   moderate  boolean      NOT NULL default '0'
-) 
+)
 |, qq|
 CREATE UNIQUE INDEX node_name ON node (name)
 | ],
@@ -136,14 +47,14 @@ CREATE TABLE content (
   verified  datetime     default NULL,
   verified_info mediumtext   NOT NULL default '',
   PRIMARY KEY (node_id, version)
-) 
+)
 | ],
         internal_links => [ qq|
 CREATE TABLE internal_links (
   link_from varchar(200) NOT NULL default '',
   link_to   varchar(200) NOT NULL default '',
   PRIMARY KEY (link_from, link_to)
-) 
+)
 | ],
         metadata => [ qq|
 CREATE TABLE metadata (
@@ -151,18 +62,63 @@ CREATE TABLE metadata (
   version        integer      NOT NULL default 0,
   metadata_type  varchar(200) NOT NULL DEFAULT '',
   metadata_value mediumtext   NOT NULL DEFAULT ''
-) 
-| ] 
+)
+| ]
+    },
+    11 => {
+        schema_info => [ qq|
+CREATE TABLE schema_info (
+  version   integer      NOT NULL default 0
+);
+|, qq|
+INSERT INTO schema_info VALUES (11)
+| ],
+
+        node => [ qq|
+CREATE TABLE node (
+  id        integer      NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name      varchar(200) NOT NULL DEFAULT '',
+  version   integer      NOT NULL default 0,
+  text      mediumtext   NOT NULL,
+  modified  datetime     default NULL,
+  moderate  boolean      NOT NULL default '0'
+)
+|, qq|
+CREATE UNIQUE INDEX node_name ON node (name)
+| ],
+        content => [ qq|
+CREATE TABLE content (
+  node_id   integer      NOT NULL,
+  version   integer      NOT NULL default 0,
+  text      mediumtext   NOT NULL,
+  modified  datetime     default NULL,
+  comment   mediumtext,
+  moderated boolean      NOT NULL default '1',
+  verified  datetime     default NULL,
+  verified_info mediumtext,
+  PRIMARY KEY (node_id, version)
+)
+| ],
+        internal_links => [ qq|
+CREATE TABLE internal_links (
+  link_from varchar(200) NOT NULL default '',
+  link_to   varchar(200) NOT NULL default '',
+  PRIMARY KEY (link_from, link_to)
+)
+| ],
+        metadata => [ qq|
+CREATE TABLE metadata (
+  node_id        integer      NOT NULL,
+  version        integer      NOT NULL default 0,
+  metadata_type  varchar(200) NOT NULL DEFAULT '',
+  metadata_value mediumtext   NOT NULL
+)
+| ]
     },
 };
 
 my %fetch_upgrades = (
-    old_to_8  => 1,
-    old_to_9  => 1,
-    old_to_10 => 1,
-    '8_to_9'  => 1,
-    '8_to_10' => 1,
-    '9_to_10' => 1,
+    '10_to_11' => 1,
 );
 
 my %upgrades = ();
@@ -224,7 +180,7 @@ sub setup {
     # Do we need to upgrade the schema?
     # (Don't check if no tables currently exist)
     my $upgrade_schema;
-    my @cur_data; 
+    my @cur_data;
     if(scalar keys %tables > 0) {
         $upgrade_schema = Wiki::Toolkit::Setup::Database::get_database_upgrade_required($dbh,$wanted_schema);
     }
@@ -271,7 +227,7 @@ sub setup {
                 } else {
                     $dbh->do($update);
                 }
-            } 
+            }
         }
     }
 

--- a/lib/Wiki/Toolkit/Store/Database.pm
+++ b/lib/Wiki/Toolkit/Store/Database.pm
@@ -12,7 +12,7 @@ use Carp qw( carp croak );
 use Digest::MD5 qw( md5_hex );
 
 $VERSION = '0.31';
-my $SCHEMA_VER = 10;
+my $SCHEMA_VER = 11;
 
 # first, detect if Encode is available - it's not under 5.6. If we _are_
 # under 5.6, give up - we'll just have to hope that nothing explodes. This

--- a/t/400_upgrade.t
+++ b/t/400_upgrade.t
@@ -7,16 +7,8 @@ use Wiki::Toolkit;
 use Wiki::Toolkit::TestLib;
 use Wiki::Toolkit::Setup::Database;
 
-# XXX needs to be more exhaustive
 my $test_sql = {
-    8 => [ qq|
-INSERT INTO node VALUES (1, 'Test node 1', 1, 'Some content', 'now')|, qq|
-INSERT INTO node VALUES (2, 'Test node 2', 1, 'More content', 'now')|, qq|
-INSERT INTO content VALUES (1, 1, 'Some content', 'now', 'no comment')|, qq|
-INSERT INTO content VALUES (2, 1, 'More content', 'now', 'no comment')|, qq|
-INSERT INTO metadata VALUES (1, 1, 'foo', 'bar')|, qq|
-INSERT INTO metadata VALUES (2, 1, 'baz', 'quux')| ],
-    9 => [ qq|
+    10 => [ qq|
 INSERT INTO node (id, name, version, text, modified) VALUES (1, 'Test node 1', 1, 'Some content', 'now')|, qq|
 INSERT INTO node (id, name, version, text, modified) VALUES (2, 'Test node 2', 1, 'More content', 'now')|, qq|
 INSERT INTO content (node_id, version, text, modified, comment) VALUES (1, 1, 'Some content', 'now', 'no comment')|, qq|
@@ -31,9 +23,6 @@ my @schemas_to_test;
 
 use Wiki::Toolkit::Setup::SQLite;
 
-my $num_mysql_only_tests = 0;
-my @mysql_databases;
-
 foreach my $db (@configured_databases) {
     my $setup_class = $db->{setup_class};
     eval "require $setup_class";
@@ -45,13 +34,9 @@ foreach my $db (@configured_databases) {
     foreach my $schema (@Wiki::Toolkit::Setup::Database::SUPPORTED_SCHEMAS) {
         push @schemas_to_test, $schema if $schema < $current_schema;
     }
-    if ( $db->{dsn} =~ /mysql/i ) {
-        $num_mysql_only_tests = 2;
-        push @mysql_databases, $db;
-    }
 }
 
-my $num_tests = (scalar @schemas_to_test * scalar @configured_databases * 2) + $num_mysql_only_tests;
+my $num_tests = (scalar @schemas_to_test * scalar @configured_databases * 2);
 if ( $num_tests == 0 ) {
     plan skip_all => "no backends configured";
 } else {
@@ -66,81 +51,50 @@ foreach my $database (@configured_databases) {
         $current_schema = eval ${$setup_class . '::SCHEMA_VERSION'};
     }
     foreach my $schema (@schemas_to_test) {
-        # Set up database with old schema
-        my $params = $database->{params};
-        $params->{wanted_schema} = $schema;
+        # Don’t try testing upgrades from schema 10 on MySQL because this
+        # schema will just fail if MySQL has strict turned on.
+        SKIP: {
+            if ( $schema == 10
+                 && $setup_class eq "Wiki::Toolkit::Setup::MySQL" ) {
+                skip "Not testing upgrades from schema 10 on MySQL", 2;
+            }
 
-        {
-            no strict 'refs';
-            eval &{$setup_class . '::cleardb'} ( $params );
-            eval &{$setup_class . '::setup'} ( $params );
-        }
+            # Set up database with old schema
+            my $params = $database->{params};
+            $params->{wanted_schema} = $schema;
 
-        my $class = $database->{class};
-        eval "require $class";
+            {
+              no strict 'refs';
+              eval &{$setup_class . '::cleardb'} ( $params );
+              eval &{$setup_class . '::setup'} ( $params );
+            }
 
-        my $dsn = $database->{dsn};
+            my $class = $database->{class};
+            eval "require $class";
 
-        my $dbh = DBI->connect($dsn, $params->{dbuser}, $params->{dbpass});
+            my $dsn = $database->{dsn};
 
-        foreach my $sql (@{$test_sql->{$schema}}) {
-            $dbh->do($sql);
-        }
+            my $dbh = DBI->connect($dsn, $params->{dbuser}, $params->{dbpass});
 
-        # Upgrade to current schema
-        delete $params->{wanted_schema};
-        {
-            no strict 'refs';
-            eval &{$setup_class . '::setup'} ( $params );
-        }
+            foreach my $sql (@{$test_sql->{$schema}}) {
+                $dbh->do($sql);
+            }
 
-        # Test the data looks sane
-        my $store = $class->new( %{$params} );
-        my %wiki_config = ( store => $store );
-        my $wiki = Wiki::Toolkit->new( %wiki_config );
-        is( $wiki->retrieve_node("Test node 1"), "Some content",
-            "can retrieve first test node after $schema to $current_schema" );
-        is( $wiki->retrieve_node("Test node 2"), "More content",
-            "can retrieve second test node after $schema to $current_schema" );
-    }
-}
+            # Upgrade to current schema
+            delete $params->{wanted_schema};
+            {
+              no strict 'refs';
+              eval &{$setup_class . '::setup'} ( $params );
+            }
 
-if ( $num_mysql_only_tests ) {
-    foreach my $database ( @mysql_databases ) {
-        my $setup_class = $database->{setup_class};
-        my $current_schema;
-        {
-            no strict 'refs';
-            $current_schema = eval ${$setup_class . '::SCHEMA_VERSION'};
-        }
-        # Set up database with old schema
-        my $params = $database->{params};
-        $params->{wanted_schema} = 9;
-
-        {
-            no strict 'refs';
-            eval &{$setup_class . '::cleardb'} ( $params );
-            eval &{$setup_class . '::setup'} ( $params );
-        }
-
-        my $class = $database->{class};
-        eval "require $class";
-
-        my $dsn = $database->{dsn};
-
-        my $dbh = DBI->connect($dsn, $params->{dbuser}, $params->{dbpass});
-        
-        # Manually create index that the upgrade also wants to create
-        eval { $dbh->do('CREATE UNIQUE INDEX node_name ON node (name);') or die $dbh->errstr };
-        is( $@, '', "Manually creating confusing index didn't die" );
-
-        # Now upgrade
-        delete $params->{wanted_schema};
-        {
-            no strict 'refs';
-            eval &{$setup_class . '::setup'} ( $params );
-            is( $@, '', "Upgrade didn't die even though node_name index had been created manually" );
+            # Make sure the data looks plausible.
+            my $store = $class->new( %{$params} );
+            my %wiki_config = ( store => $store );
+            my $wiki = Wiki::Toolkit->new( %wiki_config );
+            is( $wiki->retrieve_node("Test node 1"), "Some content",
+                "can retrieve 1st test node after $schema to $current_schema");
+            is( $wiki->retrieve_node("Test node 2"), "More content",
+                "can retrieve 2nd test node after $schema to $current_schema");
         }
     }
 }
-


### PR DESCRIPTION
Upgrade database schema to version 11 (text columns no longer have a default value, for compatibility with MySQL strict mode).
Remove code for dealing with upgrades to database schema version 10 (which came in over a decade ago).