### PR TITLE
Make tests on Travis work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ services:
 before_install:
   - mysql -e 'CREATE DATABASE wikitest;'
   - psql -c 'create database wikitest;' -U postgres
-  - cpanm --quiet --notest DBD::SQLite Plucene File::Spec::Functions Lucy File::Path Lingua::Stem DBD::Pg DBD::mysql DBIx::FullTextSearch Test::Pod Test::MockObject Hook::LexWrap Wiki::Toolkit::Formatter::UseMod
+  - cpanm --quiet --notest DBD::SQLite Plucene File::Spec::Functions Lucy File::Path Lingua::Stem DBD::Pg DBD::mysql Test::Pod Test::MockObject Hook::LexWrap Wiki::Toolkit::Formatter::UseMod
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ env:
     - WIKI_TOOLKIT_PG_DBUSER=postgres
     - WIKI_TOOLKIT_PG_DBHOST=localhost
 perl:
+  - "5.30"
+  - "5.28"
+  - "5.26"
+  - "5.24"
   - "5.22"
   - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
 services:
   - mysql
   - postgresql


### PR DESCRIPTION
Tests on Travis have not worked for a while. This fixes both reasons why. 

- older perl versions are no longer available
- DBIx::FullTextSearch is currently broken for our usage and hasn't been updated since 2003.
   This is the first step to removing the use of DBIx:FullTextSearch completely.

