### PR TITLE
Use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -219,7 +219,7 @@ WriteMakefile( (MM->can('signature_target') ? (SIGN => 1) : ()),
                PREREQ_PM    => { 'Text::WikiFormat' => '0.78', #earlier's buggy
                                  'HTML::PullParser' => 0,
                                  'Digest::MD5'      => 0,
-                                 'Digest::SHA1'     => 0,
+                                 'Digest::SHA'      => 0,
                                  'Test::More'       => 0,
                                  'Time::Piece'      => 0,
                                  'DBI'              => 0,

--- a/lib/Wiki/Toolkit/Store/MySQL.pm
+++ b/lib/Wiki/Toolkit/Store/MySQL.pm
@@ -6,10 +6,10 @@ use vars qw( @ISA $VERSION );
 
 use Wiki::Toolkit::Store::Database;
 use Carp qw/carp croak/;
-use Digest::SHA1 qw/ sha1_hex /;
+use Digest::SHA qw/ sha1_hex /;
 
 @ISA = qw( Wiki::Toolkit::Store::Database );
-$VERSION = 0.06;
+$VERSION = 0.07;
 
 =head1 NAME
 


### PR DESCRIPTION
The former is in perl core so doesn't need any additional dependencies;
the latter was removed from Debian in 2011:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=594273